### PR TITLE
fix: Provide dependencies to base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,14 @@
 FROM node:18.4.0-alpine
 
-RUN apk add --no-cache bash
+# NB: Some underlying Node dependencies have an indirect dependency on Python
+# in order to be built (yes, no kidding), more specifically have a dependency
+# on node-gyp.
+# Alpine-based images are very minimal and don't come with Python, thus the following
+# NB: --virtual bundles all listed packages into 'build-dependencies' virtual package
+# in order to remove them at once with apk
+RUN apk --no-cache --virtual build-dependencies add \
+    python3 \
+    make \
+    bash \
+    g++
+


### PR DESCRIPTION
Same change as [https://github.com/Compensate-Operations/carbon/pull/2706](https://github.com/Compensate-Operations/carbon/pull/2706), but for the image that the CI uses (see [here](https://github.com/Compensate-Operations/carbon/blob/master/terraform/common/ci_cd.tf#L312-L332))