### PR TITLE
chore: pin LTS node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.10.0-alpine
+FROM node:16.18.0-alpine
 
 # NB: Some underlying Node dependencies have an indirect dependency on Python
 # in order to be built (yes, no kidding), more specifically have a dependency


### PR DESCRIPTION
We need to switch back to Node LTS (16) in order to support Firebase Functions.

https://firebase.google.com/docs/functions/manage-functions#set_nodejs_version