### PR TITLE
chore: Add git as dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,6 @@ RUN apk --no-cache --virtual build-dependencies add \
     python3 \
     make \
     bash \
-    g++
+    g++ \
+    git
 


### PR DESCRIPTION
In order for the content-publisher CD pipeline to work, git needs to be part of the cloudbuild-node image so that the builder step can pull the necessary tag to be (re)built.

This is related to work carried under https://github.com/Compensate-Operations/carbon/pull/3241