### PR TITLE
fix: Add missing dependencies to complete Node image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
 FROM node:18.12.1-alpine
 
+# NB: Some underlying Node dependencies have an indirect dependency on Python
+# in order to be built (yes, no kidding), more specifically have a dependency
+# on node-gyp.
+# Alpine-based images are very minimal and don't come with Python, thus the following
 RUN apk --no-cache add \
     make \
     bash \
+    g++  \
+    python3 \
     git
 


### PR DESCRIPTION
See an example error:
https://console.cloud.google.com/cloud-build/builds;region=global/5677324f-dfd3-453c-8f8f-d844c98c40dd;step=2?project=compensate-infrastructure