### PR TITLE
chore: Fix ignore major Node versions for node-16 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,8 @@ updates:
       - "woodwoerk"
       - "lbinscheck"
     ignore:
-      versions: ["18"]
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
I made a mistake on the previous PR, this should fix it.